### PR TITLE
Dependency updates for ghc 7.10

### DIFF
--- a/Network/Wai/Middleware/Static.hs
+++ b/Network/Wai/Middleware/Static.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE OverloadedStrings #-}
 -- | Serve static files, subject to a policy that can filter or
 --   modify incoming URIs. The flow is:
@@ -25,14 +26,12 @@ import Caching.ExpiringCacheMap.HashECM (newECMIO, lookupECM, CacheSettings(..),
 import Control.Monad.Trans (liftIO)
 import Data.List
 import Data.Maybe (fromMaybe)
-import Data.Monoid
 import Data.Time
 import Data.Time.Clock.POSIX
 import Network.HTTP.Types (status200, status304)
 import Network.HTTP.Types.Header (RequestHeaders)
 import Network.Wai
 import System.Directory (doesFileExist)
-import System.Locale
 import System.Posix.Files
 import qualified Crypto.Hash.SHA1 as SHA1
 import qualified Data.ByteString as B
@@ -43,6 +42,14 @@ import qualified Data.ByteString.Lazy as BSL
 import qualified Data.Map as M
 import qualified Data.Text as T
 import qualified System.FilePath as FP
+
+#if (!defined(__GLASGOW_HASKELL__)) || (__GLASGOW_HASKELL__ < 710)
+import Data.Monoid
+#endif
+
+#if (!defined(MIN_VERSION_time)) || (!MIN_VERSION_time(1,5,0))
+import System.Locale
+#endif
 
 -- | Take an incoming URI and optionally modify or filter it.
 --   The result will be treated as a filepath.

--- a/wai-middleware-static.cabal
+++ b/wai-middleware-static.cabal
@@ -31,12 +31,12 @@ Library
                        cryptohash       >= 0.11     && < 0.12,
                        directory        >= 1.2.0.1  && < 1.3,
                        expiring-cache-map >= 0.0.5  && < 0.1,
-                       filepath         >= 1.3.0.1  && < 1.4,
+                       filepath         >= 1.3.0.1  && < 1.5,
                        http-types       >= 0.8.2    && < 0.9,
                        mtl              >= 2.1.2    && < 2.3,
                        old-locale       >= 1.0      && < 1.1,
                        text             >= 0.11.3.1 && < 1.3,
-                       time             >= 1.4      && < 1.5,
+                       time             >= 1.4      && < 1.6,
                        unix             >= 2.7      && < 2.8,
                        wai              >= 3.0.0    && < 3.1
 


### PR DESCRIPTION
This is not a complete fix, since with this change (and a manual update of `expiring-cache-map` to get it to build), I end up with

````
Network/Wai/Middleware/Static.hs:256:45:
    Ambiguous occurrence ‘defaultTimeLocale’
    It could refer to either ‘Data.Time.defaultTimeLocale’,
                             imported from ‘Data.Time’ at Network/Wai/Middleware/Static.hs:29:1-16
                             (and originally defined in ‘time-1.5.0.1:Data.Time.Format.Locale’)
                          or ‘System.Locale.defaultTimeLocale’,
                             imported from ‘System.Locale’ at Network/Wai/Middleware/Static.hs:35:1-20
````