### PR TITLE
Add MIME type for WOFF fonts and expose getMimeType

### DIFF
--- a/Network/Wai/Middleware/Static.hs
+++ b/Network/Wai/Middleware/Static.hs
@@ -335,6 +335,7 @@ defaultMimeTypes = M.fromList [
   ( "wax"     , "audio/x-ms-wax"                    ),
   ( "wma"     , "audio/x-ms-wma"                    ),
   ( "wmv"     , "video/x-ms-wmv"                    ),
+  ( "woff"    , "application/font-woff"             ),
   ( "xbm"     , "image/x-xbitmap"                   ),
   ( "xml"     , "text/xml"                          ),
   ( "xpm"     , "image/x-xpixmap"                   ),

--- a/Network/Wai/Middleware/Static.hs
+++ b/Network/Wai/Middleware/Static.hs
@@ -19,6 +19,8 @@ module Network.Wai.Middleware.Static
     , addBase, addSlash, contains, hasPrefix, hasSuffix, noDots, isNotAbsolute, only
     , -- * Utilities
       tryPolicy
+    , -- * MIME types
+      getMimeType
     ) where
 
 import Caching.ExpiringCacheMap.HashECM (newECMIO, lookupECM, CacheSettings(..), consistentDuration)
@@ -263,7 +265,8 @@ computeFileMeta fp =
 
 type Ascii = B.ByteString
 
-getMimeType :: FilePath -> Ascii
+-- | Guess MIME type from file extension
+getMimeType :: FilePath -> B.ByteString
 getMimeType = go . extensions
     where go [] = defaultMimeType
           go (ext:exts) = fromMaybe (go exts) $ M.lookup ext defaultMimeTypes


### PR DESCRIPTION
I found that middleware serves .woff fonts as application/octet-stream and thus browser

Second unrelated patch is exposing getMimeType. Sometimes I need to guess MIME type of file but couldn't use wai middleware. Currently only way is to copy code.