### PR TITLE
Use mime-types library

### DIFF
--- a/Network/Wai/Middleware/Static.hs
+++ b/Network/Wai/Middleware/Static.hs
@@ -26,7 +26,6 @@ module Network.Wai.Middleware.Static
 import Caching.ExpiringCacheMap.HashECM (newECMIO, lookupECM, CacheSettings(..), consistentDuration)
 import Control.Monad.Trans (liftIO)
 import Data.List
-import Data.Maybe (fromMaybe)
 #if !(MIN_VERSION_base(4,8,0))
 import Data.Monoid
 #endif
@@ -34,18 +33,17 @@ import Data.Time
 import Data.Time.Clock.POSIX
 import Network.HTTP.Types (status200, status304)
 import Network.HTTP.Types.Header (RequestHeaders)
+import Network.Mime (MimeType, defaultMimeLookup)
 import Network.Wai
 import System.Directory (doesFileExist, getModificationTime)
 #if !(MIN_VERSION_time(1,5,0))
 import System.Locale
 #endif
 import qualified Crypto.Hash.SHA1 as SHA1
-import qualified Data.ByteString as B
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Base16 as B16
 import qualified Data.ByteString.Char8 as BSC
 import qualified Data.ByteString.Lazy as BSL
-import qualified Data.Map as M
 import qualified Data.Text as T
 import qualified System.FilePath as FP
 
@@ -263,84 +261,6 @@ computeFileMeta fp =
                 , fm_fileName = fp
                 }
 
-type Ascii = B.ByteString
-
 -- | Guess MIME type from file extension
-getMimeType :: FilePath -> B.ByteString
-getMimeType = go . extensions
-    where go [] = defaultMimeType
-          go (ext:exts) = fromMaybe (go exts) $ M.lookup ext defaultMimeTypes
-
-extensions :: FilePath -> [String]
-extensions [] = []
-extensions fp = case dropWhile (/= '.') fp of
-                    [] -> []
-                    s -> let ext = tail s
-                         in ext : extensions ext
-
-defaultMimeType :: Ascii
-defaultMimeType = "application/octet-stream"
-
--- This list taken from snap-core's Snap.Util.FileServe
-defaultMimeTypes :: M.Map String Ascii
-defaultMimeTypes = M.fromList [
-  ( "asc"     , "text/plain"                        ),
-  ( "asf"     , "video/x-ms-asf"                    ),
-  ( "asx"     , "video/x-ms-asf"                    ),
-  ( "avi"     , "video/x-msvideo"                   ),
-  ( "bz2"     , "application/x-bzip"                ),
-  ( "c"       , "text/plain"                        ),
-  ( "class"   , "application/octet-stream"          ),
-  ( "conf"    , "text/plain"                        ),
-  ( "cpp"     , "text/plain"                        ),
-  ( "css"     , "text/css"                          ),
-  ( "cxx"     , "text/plain"                        ),
-  ( "dtd"     , "text/xml"                          ),
-  ( "dvi"     , "application/x-dvi"                 ),
-  ( "gif"     , "image/gif"                         ),
-  ( "gz"      , "application/x-gzip"                ),
-  ( "hs"      , "text/plain"                        ),
-  ( "htm"     , "text/html"                         ),
-  ( "html"    , "text/html"                         ),
-  ( "jar"     , "application/x-java-archive"        ),
-  ( "jpeg"    , "image/jpeg"                        ),
-  ( "jpg"     , "image/jpeg"                        ),
-  ( "js"      , "text/javascript"                   ),
-  ( "json"    , "application/json"                  ),
-  ( "log"     , "text/plain"                        ),
-  ( "m3u"     , "audio/x-mpegurl"                   ),
-  ( "mov"     , "video/quicktime"                   ),
-  ( "mp3"     , "audio/mpeg"                        ),
-  ( "mp4"     , "video/mp4"                         ),
-  ( "mpeg"    , "video/mpeg"                        ),
-  ( "mpg"     , "video/mpeg"                        ),
-  ( "ogg"     , "application/ogg"                   ),
-  ( "ogv"     , "video/ogg"                         ),
-  ( "pac"     , "application/x-ns-proxy-autoconfig" ),
-  ( "pdf"     , "application/pdf"                   ),
-  ( "png"     , "image/png"                         ),
-  ( "ps"      , "application/postscript"            ),
-  ( "qt"      , "video/quicktime"                   ),
-  ( "sig"     , "application/pgp-signature"         ),
-  ( "spl"     , "application/futuresplash"          ),
-  ( "svg"     , "image/svg+xml"                     ),
-  ( "swf"     , "application/x-shockwave-flash"     ),
-  ( "tar"     , "application/x-tar"                 ),
-  ( "tar.bz2" , "application/x-bzip-compressed-tar" ),
-  ( "tar.gz"  , "application/x-tgz"                 ),
-  ( "tbz"     , "application/x-bzip-compressed-tar" ),
-  ( "text"    , "text/plain"                        ),
-  ( "tgz"     , "application/x-tgz"                 ),
-  ( "torrent" , "application/x-bittorrent"          ),
-  ( "ttf"     , "application/x-font-truetype"       ),
-  ( "txt"     , "text/plain"                        ),
-  ( "wav"     , "audio/x-wav"                       ),
-  ( "wax"     , "audio/x-ms-wax"                    ),
-  ( "wma"     , "audio/x-ms-wma"                    ),
-  ( "wmv"     , "video/x-ms-wmv"                    ),
-  ( "woff"    , "application/font-woff"             ),
-  ( "xbm"     , "image/x-xbitmap"                   ),
-  ( "xml"     , "text/xml"                          ),
-  ( "xpm"     , "image/x-xpixmap"                   ),
-  ( "xwd"     , "image/x-xwindowdump"               ),
-  ( "zip"     , "application/zip"                   ) ]
+getMimeType :: FilePath -> MimeType
+getMimeType = defaultMimeLookup . T.pack

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,18 @@
+## 0.8.0
+* The `mime-types` library is now used to lookup MIME types from extensions.
+  As a result, some extensions now map to different MIME types. They are:
+
+  Extension | `wai-middleware-static`       | `mime-types` |
+  --------- | ----------------------------- | ------------ |
+  `class`   | `application/octet-stream`    | `application/java-vm`
+  `dtd`     | `text/xml`                    | `application/xml-dtd`
+  `jar`     | `application/x-java-archive`  | `application/java-archive`
+  `js`      | `text/javascript`             | `application/javascript`
+  `ogg`     | `application/ogg`             | `audio/ogg`
+  `ttf`     | `application/x-font-truetype` | `application/x-font-ttf`
+
+* Exposed `getMimeType` function [Shimuuar]
+
 ## 0.7.0.1
 * Fixed Windows build (by replacing `unix` dependency with equivalent `directory`
   function)

--- a/wai-middleware-static.cabal
+++ b/wai-middleware-static.cabal
@@ -33,6 +33,7 @@ Library
                        expiring-cache-map >= 0.0.5    && < 0.1,
                        filepath           >= 1.3.0.1  && < 1.5,
                        http-types         >= 0.8.2    && < 0.9,
+                       mime-types         >= 0.1.0.3  && < 0.2,
                        mtl                >= 2.1.2    && < 2.3,
                        old-locale         >= 1.0      && < 1.1,
                        text               >= 0.11.3.1 && < 1.3,

--- a/wai-middleware-static.cabal
+++ b/wai-middleware-static.cabal
@@ -1,5 +1,5 @@
 Name:                wai-middleware-static
-Version:             0.7.0.1
+Version:             0.8.0
 Synopsis:            WAI middleware that serves requests to static files.
 Homepage:            https://github.com/scotty-web/wai-middleware-static
 Bug-reports:         https://github.com/scotty-web/wai-middleware-static/issues


### PR DESCRIPTION
It appears that much of `wai-middleware-static`'s maintenance involves its list of MIME types. I propose using the dedicated [`mime-types`](http://hackage.haskell.org/package/mime-types-0.1.0.6/docs/Network-Mime.html) library to do this (`blank-canvas` already does). `mime-types`' function `defaultMimeLookup` is almost identical to `getMimeType`, except that it takes a `Text` argument instead of a `String`.