### PR TITLE
allow wai 3.2 in cabal contraints

### DIFF
--- a/wai-middleware-static.cabal
+++ b/wai-middleware-static.cabal
@@ -38,7 +38,7 @@ Library
                        old-locale         >= 1.0      && < 1.1,
                        text               >= 0.11.3.1 && < 1.3,
                        time               >= 1.4      && < 1.6,
-                       wai                >= 3.0.0    && < 3.1
+                       wai                >= 3.0.0    && < 3.3
 
   GHC-options: -Wall -fno-warn-orphans
 


### PR DESCRIPTION
A new release allowing wai 3.2 would close https://github.com/fpco/stackage/issues/1074#issuecomment-170636656