### PR TITLE
Use cryptonite instead of cryptohash

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,5 @@ dist/
 *.swp
 cabal-dev/
 .cabal-sandbox/
+.stack-work/
 cabal.sandbox.config

--- a/Network/Wai/Middleware/Static.hs
+++ b/Network/Wai/Middleware/Static.hs
@@ -40,9 +40,10 @@ import System.Directory (doesFileExist, getModificationTime)
 #if !(MIN_VERSION_time(1,5,0))
 import System.Locale
 #endif
-import qualified Crypto.Hash.SHA1 as SHA1
+import Crypto.Hash.Algorithms
+import Crypto.Hash
+import Data.ByteArray.Encoding
 import qualified Data.ByteString as BS
-import qualified Data.ByteString.Base16 as B16
 import qualified Data.ByteString.Char8 as BSC
 import qualified Data.ByteString.Lazy as BSL
 import qualified Data.Text as T
@@ -263,7 +264,7 @@ computeFileMeta fp =
        return $ FileMeta
                 { fm_lastModified =
                       BSC.pack $ formatTime defaultTimeLocale "%a, %d-%b-%Y %X %Z" mtime
-                , fm_etag = B16.encode (SHA1.hashlazy ct)
+                , fm_etag = convertToBase Base16 (hashlazy ct :: Digest SHA1)
                 , fm_fileName = fp
                 }
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,0 +1,16 @@
+# For more information, see: http://docs.haskellstack.org/en/stable/yaml_configuration/
+
+# Specifies the GHC version and set of packages available (e.g., lts-3.5, nightly-2015-09-21, ghc-7.10.2)
+resolver: lts-5.6
+
+# Local packages, usually specified by relative directory name
+packages:
+- '.'
+# Packages to be pulled from upstream that are not in the resolver (e.g., acme-missiles-0.3)
+extra-deps: []
+
+# Override default flag values for local packages and extra-deps
+flags: {}
+
+# Extra package databases containing global packages
+extra-package-dbs: []

--- a/wai-middleware-static.cabal
+++ b/wai-middleware-static.cabal
@@ -25,10 +25,10 @@ Library
   default-language:    Haskell2010
   Build-depends:
                        base               >= 4.6.0.1  && < 5,
-                       base16-bytestring  >= 0.1      && < 0.2,
                        bytestring         >= 0.10.0.2 && < 0.11,
                        containers         >= 0.5.0.0  && < 0.6,
-                       cryptohash         >= 0.11     && < 0.12,
+                       cryptonite         >= 0.10     && < 1.0,
+                       memory             >= 0.10     && < 1.0,
                        directory          >= 1.2.0.1  && < 1.3,
                        expiring-cache-map >= 0.0.5    && < 0.1,
                        filepath           >= 1.3.0.1  && < 1.5,


### PR DESCRIPTION
[cryptohash is deprecated](https://github.com/vincenthz/hs-cryptohash) in favor of cryptonite.

Also memory instead of base16-bytestring – memory is a dependency of cryptonite.

And `stack.yaml`.