### PR TITLE
Add Options object that allows providing a custom `getMimeTypes`

### DIFF
--- a/Network/Wai/Middleware/Static.hs
+++ b/Network/Wai/Middleware/Static.hs
@@ -12,6 +12,9 @@ module Network.Wai.Middleware.Static
     ( -- * Middlewares
       static, staticPolicy, unsafeStaticPolicy
     , static', staticPolicy', unsafeStaticPolicy'
+    , staticWithOptions, staticPolicyWithOptions, unsafeStaticPolicyWithOptions
+    , -- * Options
+      Options, defaultOptions, cacheContainer, setCacheContainer, mimeTypes, setMimeTypes
     , -- * Cache Control
       CachingStrategy(..), FileMeta(..), initCaching, CacheContainer
     , -- * Policies
@@ -55,6 +58,26 @@ import qualified System.FilePath as FP
 --   The result will be treated as a filepath.
 newtype Policy = Policy { tryPolicy :: String -> Maybe String -- ^ Run a policy
                         }
+
+-- | Options for 'staticWithOptions' 'Middleware'.
+data Options = Options { cacheContainer :: CacheContainer -- ^ Cache container to use
+                       , mimeTypes :: FilePath -> MimeType -- ^ Compute MimeType from file name
+                       }
+
+-- | Default options.
+--
+-- 'cacheContainer' = 'CacheContainerEmpty' -- no caching
+-- 'mimeTypes' = 'getMimeTypes' -- use 'defaultMimeLookup' from 'Network.Mime'
+defaultOptions :: Options
+defaultOptions = Options { cacheContainer = CacheContainerEmpty, mimeTypes = getMimeType }
+
+-- | Update cacheContainer of options.
+setCacheContainer :: CacheContainer -> Options -> Options
+setCacheContainer cc options = options { cacheContainer = cc }
+
+-- | Update mimeTypes of options.
+setMimeTypes :: (FilePath -> MimeType) -> Options -> Options
+setMimeTypes mts options = options { mimeTypes = mts }
 
 -- | A cache strategy which should be used to
 -- serve content matching a policy. Meta information is cached for a maxium of
@@ -145,7 +168,7 @@ isNotAbsolute = predicate $ not . FP.isAbsolute
 -- GET \"foo\/bar\" looks for \"\/home\/user\/files\/bar\"
 -- GET \"baz\/bar\" doesn't match anything
 --
-only :: [(String,String)] -> Policy
+only :: [(String, String)] -> Policy
 only al = policy (flip lookup al)
 
 -- | Serve static files out of the application root (current directory).
@@ -162,35 +185,54 @@ static = staticPolicy mempty
 static' :: CacheContainer -> Middleware
 static' cc = staticPolicy' cc mempty
 
+-- | Serve static files out of the application root (current directory).
+-- If file is found, it is streamed to the client and no further middleware is run. Takes 'Options'.
+--
+-- Note: for security reasons, this uses the 'noDots' and 'isNotAbsolute' policy by default.
+staticWithOptions :: Options -> Middleware
+staticWithOptions options = staticPolicyWithOptions options mempty
+
 -- | Serve static files subject to a 'Policy'. Disables caching.
 --
 -- Note: for security reasons, this uses the 'noDots' and 'isNotAbsolute' policy by default.
 staticPolicy :: Policy -> Middleware
-staticPolicy = staticPolicy' CacheContainerEmpty
+staticPolicy = staticPolicy' (cacheContainer defaultOptions)
 
 -- | Serve static files subject to a 'Policy' using a specified 'CachingStrategy'
 --
 -- Note: for security reasons, this uses the 'noDots' and 'isNotAbsolute' policy by default.
 staticPolicy' :: CacheContainer -> Policy -> Middleware
-staticPolicy' cc p = unsafeStaticPolicy' cc $ noDots >-> isNotAbsolute >-> p
+staticPolicy' cc p = unsafeStaticPolicy' (mimeTypes defaultOptions) cc $ noDots >-> isNotAbsolute >-> p
+
+-- | Serve static files subject to a 'Policy' using specified 'Options'
+--
+-- Note: for security reasons, this uses the 'noDots' and 'isNotAbsolute' policy by default.
+staticPolicyWithOptions :: Options -> Policy -> Middleware
+staticPolicyWithOptions options p = unsafeStaticPolicyWithOptions options $ noDots >-> isNotAbsolute >-> p
 
 -- | Serve static files subject to a 'Policy'. Unlike 'static' and 'staticPolicy', this
--- has no policies enabled by default, and is hence insecure. Disables caching.
+-- has no policies enabled by default and is hence insecure. Disables caching.
 unsafeStaticPolicy :: Policy -> Middleware
-unsafeStaticPolicy = unsafeStaticPolicy' CacheContainerEmpty
+unsafeStaticPolicy = unsafeStaticPolicy' (mimeTypes defaultOptions) (cacheContainer defaultOptions)
+
+-- | Serve static files subject to a 'Policy'. Unlike 'staticWithOptions' and 'staticPolicyWithOptions',
+-- this has no policies enabled by default and is hence insecure. Takes 'Options'.
+unsafeStaticPolicyWithOptions :: Options -> Policy -> Middleware
+unsafeStaticPolicyWithOptions options = unsafeStaticPolicy' (mimeTypes options) (cacheContainer options)
 
 -- | Serve static files subject to a 'Policy'. Unlike 'static' and 'staticPolicy', this
 -- has no policies enabled by default, and is hence insecure. Also allows to set a 'CachingStrategy'.
 unsafeStaticPolicy' ::
-    CacheContainer
+    (FilePath -> MimeType)
+    -> CacheContainer
     -> Policy
     -> Middleware
-unsafeStaticPolicy' cacheContainer p app req callback =
+unsafeStaticPolicy' getMimeTypeFn cc p app req callback =
     maybe (app req callback)
           (\fp ->
                do exists <- liftIO $ doesFileExist fp
                   if exists
-                  then case cacheContainer of
+                  then case cc of
                          CacheContainerEmpty ->
                              sendFile fp []
                          CacheContainer _ NoCaching ->
@@ -224,7 +266,7 @@ unsafeStaticPolicy' cacheContainer p app req callback =
              callback $ responseLBS status304 cacheHeaders BSL.empty
       sendFile fp extraHeaders =
           do let basicHeaders =
-                     [ ("Content-Type", getMimeType fp)
+                     [ ("Content-Type", getMimeTypeFn fp)
                      ]
                  headers =
                      basicHeaders ++ extraHeaders

--- a/Network/Wai/Middleware/Static.hs
+++ b/Network/Wai/Middleware/Static.hs
@@ -66,8 +66,12 @@ data Options = Options { cacheContainer :: CacheContainer -- ^ Cache container t
 
 -- | Default options.
 --
--- 'cacheContainer' = 'CacheContainerEmpty' -- no caching
--- 'mimeTypes' = 'getMimeTypes' -- use 'defaultMimeLookup' from 'Network.Mime'
+-- @
+-- 'Options'
+-- { 'cacheContainer' = 'CacheContainerEmpty' -- no caching
+-- , 'mimeTypes'      = 'getMimeType'         -- use 'defaultMimeLookup' from 'Network.Mime'
+-- }
+-- @
 defaultOptions :: Options
 defaultOptions = Options { cacheContainer = CacheContainerEmpty, mimeTypes = getMimeType }
 
@@ -182,6 +186,7 @@ static = staticPolicy mempty
 -- If file is found, it is streamed to the client and no further middleware is run. Allows a 'CachingStrategy'.
 --
 -- Note: for security reasons, this uses the 'noDots' and 'isNotAbsolute' policy by default.
+{-# DEPRECATED static' "Use 'staticWithOptions' instead." #-}
 static' :: CacheContainer -> Middleware
 static' cc = staticPolicy' cc mempty
 
@@ -201,6 +206,7 @@ staticPolicy = staticPolicy' (cacheContainer defaultOptions)
 -- | Serve static files subject to a 'Policy' using a specified 'CachingStrategy'
 --
 -- Note: for security reasons, this uses the 'noDots' and 'isNotAbsolute' policy by default.
+{-# DEPRECATED staticPolicy' "Use 'staticPolicyWithOptions' instead." #-}
 staticPolicy' :: CacheContainer -> Policy -> Middleware
 staticPolicy' cc p = unsafeStaticPolicy' cc $ noDots >-> isNotAbsolute >-> p
 
@@ -217,6 +223,7 @@ unsafeStaticPolicy = unsafeStaticPolicy' (cacheContainer defaultOptions)
 
 -- | Serve static files subject to a 'Policy'. Unlike 'static' and 'staticPolicy', this
 -- has no policies enabled by default, and is hence insecure. Also allows to set a 'CachingStrategy'.
+{-# DEPRECATED unsafeStaticPolicy' "Use 'unsafeStaticPolicyWithOptions' instead." #-}
 unsafeStaticPolicy' :: CacheContainer -> Policy -> Middleware
 unsafeStaticPolicy' cc = unsafeStaticPolicyWithOptions (setCacheContainer cc defaultOptions)
 

--- a/Network/Wai/Middleware/Static.hs
+++ b/Network/Wai/Middleware/Static.hs
@@ -14,7 +14,7 @@ module Network.Wai.Middleware.Static
     , static', staticPolicy', unsafeStaticPolicy'
     , staticWithOptions, staticPolicyWithOptions, unsafeStaticPolicyWithOptions
     , -- * Options
-      Options, defaultOptions, cacheContainer, setCacheContainer, mimeTypes, setMimeTypes
+      Options(..), defaultOptions
     , -- * Cache Control
       CachingStrategy(..), FileMeta(..), initCaching, CacheContainer
     , -- * Policies
@@ -60,6 +60,8 @@ newtype Policy = Policy { tryPolicy :: String -> Maybe String -- ^ Run a policy
                         }
 
 -- | Options for 'staticWithOptions' 'Middleware'.
+--
+-- Options can be set using record syntax on 'defaultOptions' with the fields below.
 data Options = Options { cacheContainer :: CacheContainer -- ^ Cache container to use
                        , mimeTypes :: FilePath -> MimeType -- ^ Compute MimeType from file name
                        }
@@ -74,14 +76,6 @@ data Options = Options { cacheContainer :: CacheContainer -- ^ Cache container t
 -- @
 defaultOptions :: Options
 defaultOptions = Options { cacheContainer = CacheContainerEmpty, mimeTypes = getMimeType }
-
--- | Update cacheContainer of options.
-setCacheContainer :: CacheContainer -> Options -> Options
-setCacheContainer cc options = options { cacheContainer = cc }
-
--- | Update mimeTypes of options.
-setMimeTypes :: (FilePath -> MimeType) -> Options -> Options
-setMimeTypes mts options = options { mimeTypes = mts }
 
 -- | A cache strategy which should be used to
 -- serve content matching a policy. Meta information is cached for a maxium of
@@ -225,7 +219,7 @@ unsafeStaticPolicy = unsafeStaticPolicy' (cacheContainer defaultOptions)
 -- has no policies enabled by default, and is hence insecure. Also allows to set a 'CachingStrategy'.
 {-# DEPRECATED unsafeStaticPolicy' "Use 'unsafeStaticPolicyWithOptions' instead." #-}
 unsafeStaticPolicy' :: CacheContainer -> Policy -> Middleware
-unsafeStaticPolicy' cc = unsafeStaticPolicyWithOptions (setCacheContainer cc defaultOptions)
+unsafeStaticPolicy' cc = unsafeStaticPolicyWithOptions (defaultOptions { cacheContainer = cc })
 
 -- | Serve static files subject to a 'Policy'. Unlike 'staticWithOptions' and 'staticPolicyWithOptions',
 -- this has no policies enabled by default and is hence insecure. Takes 'Options'.

--- a/Network/Wai/Middleware/Static.hs
+++ b/Network/Wai/Middleware/Static.hs
@@ -14,7 +14,7 @@ module Network.Wai.Middleware.Static
     , static', staticPolicy', unsafeStaticPolicy'
     , staticWithOptions, staticPolicyWithOptions, unsafeStaticPolicyWithOptions
     , -- * Options
-      Options(..), defaultOptions
+      Options, cacheContainer, mimeTypes, defaultOptions
     , -- * Cache Control
       CachingStrategy(..), FileMeta(..), initCaching, CacheContainer
     , -- * Policies

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,7 @@
+## 0.8.3 [2019.10.14]
+* Add `Options`, `staticWithOptions`, `staticPolicyWithOptions`, and `unsafeStaticPolicyWithOptions`.
+* Parameterize Middleware with options allowing custom file name to MIME type mapping.
+
 ## 0.8.2 [2018.04.07]
 * Remove unused test suite.
 

--- a/wai-middleware-static.cabal
+++ b/wai-middleware-static.cabal
@@ -1,5 +1,5 @@
 Name:                wai-middleware-static
-Version:             0.8.2
+Version:             0.8.3
 Synopsis:            WAI middleware that serves requests to static files.
 Homepage:            https://github.com/scotty-web/wai-middleware-static
 Bug-reports:         https://github.com/scotty-web/wai-middleware-static/issues


### PR DESCRIPTION
NOTE: This pull request includes changes to the CHANGELOG and an update to the cabal file to bump the version indicating a non-breaking change (as the changes are pure additions).

I chose a fairly heavyweight style for the `Options` object. Feel free to change that or anything else.

Fixes #12.