### PR TITLE
Only serve static files on HEAD or GET requests

### DIFF
--- a/Network/Wai/Middleware/Static.hs
+++ b/Network/Wai/Middleware/Static.hs
@@ -27,7 +27,6 @@ module Network.Wai.Middleware.Static
     ) where
 
 import Caching.ExpiringCacheMap.HashECM (newECMIO, lookupECM, CacheSettings(..), consistentDuration)
-import Control.Monad.Trans (liftIO)
 import Control.Monad
 import Data.List
 #if !(MIN_VERSION_base(4,8,0))
@@ -241,7 +240,7 @@ unsafeStaticPolicyWithOptions options p app req callback =
 
       tryStaticFile :: FilePath -> IO ResponseReceived
       tryStaticFile fp = do
-          exists <- liftIO $ doesFileExist fp
+          exists <- doesFileExist fp
           if exists
                   then case cacheContainer options of
                          CacheContainerEmpty ->

--- a/Network/Wai/Middleware/Static.hs
+++ b/Network/Wai/Middleware/Static.hs
@@ -28,6 +28,7 @@ module Network.Wai.Middleware.Static
 
 import Caching.ExpiringCacheMap.HashECM (newECMIO, lookupECM, CacheSettings(..), consistentDuration)
 import Control.Monad.Trans (liftIO)
+import Control.Monad
 import Data.List
 #if !(MIN_VERSION_base(4,8,0))
 import Data.Monoid (Monoid(..))
@@ -37,8 +38,7 @@ import Data.Semigroup (Semigroup(..))
 #endif
 import Data.Time
 import Data.Time.Clock.POSIX
-import Network.HTTP.Types (status200, status304)
-import Network.HTTP.Types.Header (RequestHeaders)
+import Network.HTTP.Types
 import Network.Mime (MimeType, defaultMimeLookup)
 import Network.Wai
 import System.Directory (doesFileExist, getModificationTime)
@@ -56,7 +56,7 @@ import qualified System.FilePath as FP
 
 -- | Take an incoming URI and optionally modify or filter it.
 --   The result will be treated as a filepath.
-newtype Policy = Policy { tryPolicy :: String -> Maybe String -- ^ Run a policy
+newtype Policy = Policy { tryPolicy :: String -> Maybe FilePath -- ^ Run a policy
                         }
 
 -- | Options for 'staticWithOptions' 'Middleware'.
@@ -234,10 +234,15 @@ unsafeStaticPolicy' cc = unsafeStaticPolicyWithOptions (defaultOptions { cacheCo
 -- this has no policies enabled by default and is hence insecure. Takes 'Options'.
 unsafeStaticPolicyWithOptions :: Options -> Policy -> Middleware
 unsafeStaticPolicyWithOptions options p app req callback =
-    maybe (app req callback)
-          (\fp ->
-               do exists <- liftIO $ doesFileExist fp
-                  if exists
+    maybe serveUpstream tryStaticFile mCandidateFile
+    where
+      serveUpstream :: IO ResponseReceived
+      serveUpstream = app req callback
+
+      tryStaticFile :: FilePath -> IO ResponseReceived
+      tryStaticFile fp = do
+          exists <- liftIO $ doesFileExist fp
+          if exists
                   then case cacheContainer options of
                          CacheContainerEmpty ->
                              sendFile fp []
@@ -248,9 +253,19 @@ unsafeStaticPolicyWithOptions options p app req callback =
                                 if checkNotModified fileMeta (readHeader "If-Modified-Since") (readHeader "If-None-Match")
                                 then sendNotModified fileMeta strategy
                                 else sendFile fp (computeHeaders fileMeta strategy)
-                  else app req callback)
+                  else serveUpstream
+
+      mCandidateFile :: Maybe FilePath
+      mCandidateFile =
+          guard isHeadOrGet >>
           (tryPolicy p $ T.unpack $ T.intercalate "/" $ pathInfo req)
-    where
+          where
+            method :: Method
+            method = requestMethod req
+
+            isHeadOrGet :: Bool
+            isHeadOrGet = method == methodHead || method == methodGet
+
       readHeader header =
           lookup header $ requestHeaders req
       checkNotModified fm modSince etag =

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,6 @@
+## 0.9.0 [unreleased]
+* Only serve static files on `HEAD` or `GET` requests
+
 ## 0.8.3 [2019.10.20]
 * Add `Options`, `staticWithOptions`, `staticPolicyWithOptions`, and `unsafeStaticPolicyWithOptions`.
 * Parameterize Middleware with options allowing custom file name to MIME type mapping.

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,17 +1,1 @@
-# For more information, see: http://docs.haskellstack.org/en/stable/yaml_configuration/
-
-# Specifies the GHC version and set of packages available (e.g., lts-3.5, nightly-2015-09-21, ghc-7.10.2)
-resolver: lts-5.6
-
-# Local packages, usually specified by relative directory name
-packages:
-- '.'
-# Packages to be pulled from upstream that are not in the resolver (e.g., acme-missiles-0.3)
-extra-deps:
-- hspec-expectations-lifted-0.5.0
-
-# Override default flag values for local packages and extra-deps
-flags: {}
-
-# Extra package databases containing global packages
-extra-package-dbs: []
+resolver: lts-16.13

--- a/stack.yaml
+++ b/stack.yaml
@@ -7,7 +7,8 @@ resolver: lts-5.6
 packages:
 - '.'
 # Packages to be pulled from upstream that are not in the resolver (e.g., acme-missiles-0.3)
-extra-deps: []
+extra-deps:
+- hspec-expectations-lifted-0.5.0
 
 # Override default flag values for local packages and extra-deps
 flags: {}

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -1,4 +1,0 @@
-module Main (main) where
-
-main :: IO ()
-main = return ()

--- a/test/Network/Wai/Middleware/StaticSpec.hs
+++ b/test/Network/Wai/Middleware/StaticSpec.hs
@@ -1,0 +1,41 @@
+{-# LANGUAGE OverloadedStrings #-}
+module Network.Wai.Middleware.StaticSpec (spec) where
+
+import           Test.Hspec hiding (shouldReturn)
+import           Test.Hspec.Expectations.Lifted
+import           Test.Hspec.Wai
+import           Test.Mockery.Directory
+
+import           Web.Scotty (scottyApp)
+import           Network.Wai.Test (SResponse(..))
+import           Network.HTTP.Types.Status
+
+import           Network.Wai.Middleware.Static
+
+spec :: Spec
+spec = around_ inTempDirectory $ do
+  describe "static" $ with (static `fmap` scottyApp (return ())) $ do
+    before_ (writeFile "foo.html" "some content") $ do
+      context "on HEAD" $ do
+        it "serves static file" $ do
+          request "HEAD" "/foo.html" [] "" `shouldReturn` SResponse {
+            simpleStatus = status200
+          , simpleHeaders = [("Content-Type", "text/html")]
+          , simpleBody = "some content"
+          }
+
+      context "on GET" $ do
+        it "serves static file" $ do
+          get "/foo.html" `shouldReturn` SResponse {
+            simpleStatus = status200
+          , simpleHeaders = [("Content-Type", "text/html")]
+          , simpleBody = "some content"
+          }
+
+      context "otherwise" $ do
+        it "serves upstream" $ do
+          post "/foo.html" "" `shouldReturn` SResponse {
+            simpleStatus = status404
+          , simpleHeaders = [("Content-Type", "text/html")]
+          , simpleBody = "<h1>404: File Not Found!</h1>"
+          }

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -1,0 +1,1 @@
+{-# OPTIONS_GHC -fforce-recomp -F -pgmF hspec-discover #-}

--- a/wai-middleware-static.cabal
+++ b/wai-middleware-static.cabal
@@ -1,5 +1,5 @@
 Name:                wai-middleware-static
-Version:             0.8.3
+Version:             0.9.0
 Synopsis:            WAI middleware that serves requests to static files.
 Homepage:            https://github.com/scotty-web/wai-middleware-static
 Bug-reports:         https://github.com/scotty-web/wai-middleware-static/issues

--- a/wai-middleware-static.cabal
+++ b/wai-middleware-static.cabal
@@ -42,7 +42,6 @@ Library
                        filepath           >= 1.3.0.1  && < 1.5,
                        http-types         >= 0.8.2    && < 0.13,
                        mime-types         >= 0.1.0.3  && < 0.2,
-                       mtl                >= 2.1.2    && < 2.3,
                        old-locale         >= 1.0      && < 1.1,
                        semigroups         >= 0.18     && < 1,
                        text               >= 0.11.3.1 && < 1.3,

--- a/wai-middleware-static.cabal
+++ b/wai-middleware-static.cabal
@@ -51,6 +51,24 @@ Library
 
   GHC-options: -Wall -fno-warn-orphans
 
+test-suite spec
+  main-is:             Spec.hs
+  other-modules:       Network.Wai.Middleware.StaticSpec
+  type:                exitcode-stdio-1.0
+  default-language:    Haskell2010
+  hs-source-dirs:      test
+  build-depends:       base,
+                       hspec == 2.*,
+                       hspec-expectations-lifted,
+                       hspec-wai >= 0.6.3,
+                       mockery,
+                       scotty,
+                       wai-extra,
+                       http-types,
+                       wai-middleware-static
+  build-tool-depends:  hspec-discover:hspec-discover == 2.*
+  GHC-options:         -Wall
+
 source-repository head
   type:     git
   location: git://github.com/scotty-web/wai-middleware-static.git


### PR DESCRIPTION
Serving a static file on `POST`, `PUT`, etc. is arguably broken.

We now delegate anything other than `HEAD` or `GET` to upstream.

This enables relevant use cases, e.g. a static log-in page and an upstream `POST` handler for it.

If upstream doesn't handle a specific method, it should generate an appropriate status code (currently, ideally 403, as 405 will require some more work in `wai-middleware-static` to augment any `Allow` header to be standard compliant).