### PR TITLE
Replace `cryptonite`/`memory` with `cryptohash-sha1`/`base16-bytestring`

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -8,9 +8,9 @@
 #
 # For more information, see https://github.com/haskell-CI/haskell-ci
 #
-# version: 0.13.20211116
+# version: 0.14.3
 #
-# REGENDATA ("0.13.20211116",["--config=cabal.haskell-ci","cabal.project"])
+# REGENDATA ("0.14.3",["--config=cabal.haskell-ci","cabal.project"])
 #
 name: Haskell-CI
 on:
@@ -28,15 +28,15 @@ jobs:
     strategy:
       matrix:
         include:
-          - compiler: ghc-9.2.1
+          - compiler: ghc-9.2.2
             compilerKind: ghc
-            compilerVersion: 9.2.1
+            compilerVersion: 9.2.2
             setup-method: ghcup
-            allow-failure: true
-          - compiler: ghc-9.0.1
+            allow-failure: false
+          - compiler: ghc-9.0.2
             compilerKind: ghc
-            compilerVersion: 9.0.1
-            setup-method: hvr-ppa
+            compilerVersion: 9.0.2
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.10.7
             compilerKind: ghc
@@ -91,7 +91,7 @@ jobs:
           apt-get install -y --no-install-recommends gnupg ca-certificates dirmngr curl git software-properties-common libtinfo5
           if [ "${{ matrix.setup-method }}" = ghcup ]; then
             mkdir -p "$HOME/.ghcup/bin"
-            curl -sL https://downloads.haskell.org/ghcup/0.1.17.3/x86_64-linux-ghcup-0.1.17.3 > "$HOME/.ghcup/bin/ghcup"
+            curl -sL https://downloads.haskell.org/ghcup/0.1.17.5/x86_64-linux-ghcup-0.1.17.5 > "$HOME/.ghcup/bin/ghcup"
             chmod a+x "$HOME/.ghcup/bin/ghcup"
             "$HOME/.ghcup/bin/ghcup" install ghc "$HCVER"
             "$HOME/.ghcup/bin/ghcup" install cabal 3.6.2.0
@@ -100,7 +100,7 @@ jobs:
             apt-get update
             apt-get install -y "$HCNAME"
             mkdir -p "$HOME/.ghcup/bin"
-            curl -sL https://downloads.haskell.org/ghcup/0.1.17.3/x86_64-linux-ghcup-0.1.17.3 > "$HOME/.ghcup/bin/ghcup"
+            curl -sL https://downloads.haskell.org/ghcup/0.1.17.5/x86_64-linux-ghcup-0.1.17.5 > "$HOME/.ghcup/bin/ghcup"
             chmod a+x "$HOME/.ghcup/bin/ghcup"
             "$HOME/.ghcup/bin/ghcup" install cabal 3.6.2.0
           fi
@@ -133,7 +133,7 @@ jobs:
           echo "HCNUMVER=$HCNUMVER" >> "$GITHUB_ENV"
           echo "ARG_TESTS=--enable-tests" >> "$GITHUB_ENV"
           echo "ARG_BENCH=--enable-benchmarks" >> "$GITHUB_ENV"
-          if [ $((HCNUMVER >= 90200)) -ne 0 ] ; then echo "HEADHACKAGE=true" >> "$GITHUB_ENV" ; else echo "HEADHACKAGE=false" >> "$GITHUB_ENV" ; fi
+          echo "HEADHACKAGE=false" >> "$GITHUB_ENV"
           echo "ARG_COMPILER=--$HCKIND --with-compiler=$HC" >> "$GITHUB_ENV"
           echo "GHCJSARITH=0" >> "$GITHUB_ENV"
         env:
@@ -162,17 +162,6 @@ jobs:
           repository hackage.haskell.org
             url: http://hackage.haskell.org/
           EOF
-          if $HEADHACKAGE; then
-          cat >> $CABAL_CONFIG <<EOF
-          repository head.hackage.ghc.haskell.org
-             url: https://ghc.gitlab.haskell.org/head.hackage/
-             secure: True
-             root-keys: 7541f32a4ccca4f97aea3b22f5e593ba2c0267546016b992dfadcd2fe944e55d
-                        26021a13b401500c8eb2761ca95c61f2d625bfef951b939a8124ed12ecf07329
-                        f76d08be13e9a61a377a85e2fb63f4c5435d40f8feb3e12eb05905edb8cdea89
-             key-threshold: 3
-          EOF
-          fi
           cat >> $CABAL_CONFIG <<EOF
           program-default-options
             ghc-options: $GHCJOBS +RTS -M3G -RTS
@@ -226,9 +215,6 @@ jobs:
           package wai-middleware-static
             ghc-options: -Werror
           EOF
-          if $HEADHACKAGE; then
-          echo "allow-newer: $($HCPKG list --simple-output | sed -E 's/([a-zA-Z-]+)-[0-9.]+/*:\1,/g')" >> cabal.project
-          fi
           $HCPKG list --simple-output --names-only | perl -ne 'for (split /\s+/) { print "constraints: $_ installed\n" unless /^(wai-middleware-static)$/; }' >> cabal.project.local
           cat cabal.project
           cat cabal.project.local

--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -212,6 +212,8 @@ jobs:
           if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then echo "package wai-middleware-static" >> cabal.project ; fi
           if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then echo "    ghc-options: -Werror=missing-methods" >> cabal.project ; fi
           cat >> cabal.project <<EOF
+          constraints: basement < 0.0.13 || > 0.0.13
+
           package wai-middleware-static
             ghc-options: -Werror
           EOF

--- a/Network/Wai/Middleware/Static.hs
+++ b/Network/Wai/Middleware/Static.hs
@@ -28,6 +28,8 @@ module Network.Wai.Middleware.Static
 
 import Caching.ExpiringCacheMap.HashECM (newECMIO, lookupECM, CacheSettings(..), consistentDuration)
 import Control.Monad
+import qualified Crypto.Hash.SHA1 as SHA1
+import qualified Data.ByteString.Base16 as Base16
 import qualified Data.List as L
 #if !(MIN_VERSION_base(4,8,0))
 import Data.Monoid (Monoid(..))
@@ -44,9 +46,9 @@ import System.Directory (doesFileExist, getModificationTime)
 #if !(MIN_VERSION_time(1,5,0))
 import System.Locale
 #endif
-import Crypto.Hash.Algorithms
-import Crypto.Hash
-import Data.ByteArray.Encoding
+-- import Crypto.Hash.Algorithms
+-- import Crypto.Hash
+-- import Data.ByteArray.Encoding
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Char8 as BSC
 import qualified Data.ByteString.Lazy as BSL
@@ -328,7 +330,7 @@ computeFileMeta fp =
        return $ FileMeta
                 { fm_lastModified =
                       BSC.pack $ formatTime defaultTimeLocale "%a, %d-%b-%Y %X %Z" mtime
-                , fm_etag = convertToBase Base16 (hashlazy ct :: Digest SHA1)
+                , fm_etag = Base16.encode (SHA1.hashlazy ct)
                 , fm_fileName = fp
                 }
 

--- a/cabal.haskell-ci
+++ b/cabal.haskell-ci
@@ -2,4 +2,3 @@ distribution:           bionic
 no-tests-no-benchmarks: False
 unconstrained:          False
 local-ghc-options:      -Werror
-head-hackage:           >=9.2

--- a/cabal.project
+++ b/cabal.project
@@ -1,1 +1,6 @@
 packages: .
+
+constraints:
+  -- Needed to allow GHC 8.0 to build the test suite
+  -- See https://github.com/haskell-foundation/foundation/issues/561
+  basement < 0.0.13 || > 0.0.13

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,8 @@
+## next [????.??.??]
+* Allow building with GHC 9.2.
+* Replace the `cryptonite` and `memory` dependencies with equivalent
+  functionality from `cryptohash-sha1` and `base16-bytestring`.
+
 ## 0.9.1 [2021.10.31]
 * Always import `Data.List` qualified.
 

--- a/wai-middleware-static.cabal
+++ b/wai-middleware-static.cabal
@@ -26,8 +26,8 @@ tested-with:         GHC == 7.6.3
                    , GHC == 8.6.5
                    , GHC == 8.8.4
                    , GHC == 8.10.7
-                   , GHC == 9.0.1
-                   , GHC == 9.2.1
+                   , GHC == 9.0.2
+                   , GHC == 9.2.2
 Extra-source-files:  changelog.md, README.md
 
 Library
@@ -35,10 +35,10 @@ Library
   default-language:    Haskell2010
   Build-depends:
                        base               >= 4.6.0.1  && < 5,
+                       base16-bytestring  >= 0.1      && < 1.1,
                        bytestring         >= 0.10.0.2 && < 0.12,
                        containers         >= 0.5.0.0  && < 0.7,
-                       cryptonite         >= 0.10     && < 1.0,
-                       memory             >= 0.10     && < 1.0,
+                       cryptohash-sha1    >= 0.11     && < 0.12,
                        directory          >= 1.2.0.1  && < 1.4,
                        expiring-cache-map >= 0.0.5    && < 0.1,
                        filepath           >= 1.3.0.1  && < 1.5,


### PR DESCRIPTION
This finally allows `wai-middleware-static` to build on GHC 9.2 without the need for `head.hackage`.